### PR TITLE
Adding back reduce function

### DIFF
--- a/classes/dataStructs/@adaptationData/adaptationData.m
+++ b/classes/dataStructs/@adaptationData/adaptationData.m
@@ -759,7 +759,11 @@ classdef adaptationData
             trialNums=this.metaData.getTrialsInCondition(conditionNames);
         end
 
-
+        function newThis=reduce(this, parametersToKeep)
+            newThis=this;
+            newThis.data=newThis.data.getDataAsPS(parametersToKeep);
+        end
+	
         %Stats testing:
         % 1) Multiple groups
 


### PR DESCRIPTION
Adding back line of code that help to created reduce version of the params files. You can pick which parameters you want to keep. This is relevant when sharing publish data