### PR TITLE
Remove Bias

### DIFF
--- a/classes/dataStructs/@adaptationData/adaptationData.m
+++ b/classes/dataStructs/@adaptationData/adaptationData.m
@@ -107,9 +107,9 @@ classdef adaptationData
 
         [newThis,baseValues,typeList]=removeBiasV2(this,conditions,normalizeFlag) %Going to deprecate in favor of removeBiasV3's simpler code
         [newThis,baseValues,typeList]=removeBiasV3(this,conditions,normalizeFlag)
-        [newThis,baseValues,typeList]=removeBiasV4(this,conditions,normalizeFlag)
+        [newThis,baseValues,typeList]=removeBiasV4(this,conditions,normalizeFlag,padWithNaNFlag)
 
-        function [newThis,baseValues,typeList]=removeBias(this,conditions)
+        function [newThis,baseValues,typeList]=removeBias(this,conditions, padWithNaNFlag)
         % Removes baseline value for all parameters.
         % removeBias('condition') or removeBias({'Condition1','Condition2',...})
         % removes the median value of every parameter from each trial of the
@@ -132,9 +132,13 @@ classdef adaptationData
             if nargin<2
                 conditions=[];
             end
-%             [newThis,baseValues,typeList]=removeBiasV3(this,conditions);
-%             %Marcela Commented this for the R01
-            [newThis,baseValues,typeList]=removeBiasV4(this,conditions);
+            
+            if nargin<3
+                padWithNaNFlag=false;
+            end
+            %             [newThis,baseValues,typeList]=removeBiasV3(this,conditions);
+            %             %Marcela Commented this for the R01
+            [newThis,baseValues,typeList]=removeBiasV4(this,conditions,[],padWithNaNFlag);
             newThis.TMbias_=baseValues(strcmp(typeList,'TM'),:);
             newThis.OGbias_=baseValues(strcmp(typeList,'OG'),:);
             newThis.INbias_=baseValues(strcmp(typeList,'IN'),:);

--- a/classes/dataStructs/@adaptationData/removeBiasV4.m
+++ b/classes/dataStructs/@adaptationData/removeBiasV4.m
@@ -1,4 +1,4 @@
-function [newThis,baseValues,typeList]=removeBiasV4(this,refConditions,normalizeFlag)
+function [newThis,baseValues,typeList]=removeBiasV4(this,refConditions,normalizeFlag, padWithNaNFlag)
 % removeBias('condition') or removeBias({'Condition1','Condition2',...})
 % removes the median value of EVERY parameter (phaseShift, temporal parameters, etc included!)
 % from each trial that is the same type as the condition entered. If no
@@ -33,6 +33,9 @@ if nargin<3 || isempty(normalizeFlag)
     normalizeFlag=0;
 end
 
+if nargin<4 || isempty(padWithNaNFlag)
+    padWithNaNFlag=false;
+end
 
 trialsInCond=this.metaData.trialsInCondition;
 % trialTypes=this.data.trialTypes;
@@ -58,7 +61,7 @@ for itype=1:length(types)
     %Remove baseline tendencies from all itype trials
     if ~isempty(baseCond)
         % CJS NEW 1/16/2019 -- treats OG and TM the same, subtracts the last 40-5 strides of baseline 
-        base=getEarlyLateData_v2(this.removeBadStrides,labels,baseCond,0,-40,5,10); %Last 40, exempting very last 5 and first 10
+        base=getEarlyLateData_v2(this.removeBadStrides,labels,baseCond,0,-40,5,1,padWithNaNFlag); %Last 40, exempting very last 5 and first 10
         base=nanmean(squeeze(base{1}));
         [data, inds]=this.getParamInTrial(labels,allTrials);
         if normalizeFlag==0


### PR DESCRIPTION
Add padwithnan flag to have a lees conservative approach when there are less strides than the number specified. This by default is set to false, but it could be changed when calling the remove bias function by the experimenter.