### PR TITLE
Add support to process Hreflex stimulus pin

### DIFF
--- a/classes/dataStructs/@labData/labData.m
+++ b/classes/dataStructs/@labData/labData.m
@@ -12,6 +12,8 @@ classdef labData
 %   beltSpeedSetData - labTS with commands sent to treadmill
 %   beltSpeedReadData - labTS with speed read from treadmill
 %   footSwitchData - labTS with data from foot switches
+%   HreflexPin - labTS with a analog signal with a spike once in a while representing time when an
+%               H-reflex stimulation is being delivered.
 %
 %labData methods:
 %   getMarkerData - accessor method for marker data
@@ -43,13 +45,14 @@ classdef labData
         beltSpeedSetData %labTS, sent commands to treadmill
         beltSpeedReadData %labTS, speed read from treadmill
         footSwitchData %labTS
+        HreflexPin %labTS, this should contain pin readings for left and right leg, it's a sync signal that shows a spike once in a while when an H reflex stimulus is being delivered.
     end
     
     %%
     methods
         
         %Constructor:
-        function this=labData(metaData,markerData,EMGData,GRFData,beltSpeedSetData,beltSpeedReadData,accData,EEGData,footSwitches)
+        function this=labData(metaData,markerData,EMGData,GRFData,beltSpeedSetData,beltSpeedReadData,accData,EEGData,footSwitches,HreflexPin)
             %----------------
             
             %if nargin<1 || isempty(metaData)
@@ -127,7 +130,14 @@ classdef labData
                 ME=MException('labData:Constructor','Ninth argument (footSwitches) should be a LabTimeSeries object.');
                 throw(ME);
             end
-            
+            if nargin<10 || isempty(HreflexPin)
+                this.HreflexPin=[];
+            elseif isa(HreflexPin,'labTimeSeries')
+                this.HreflexPin=HreflexPin; %Empty or labels 'L' and 'R'
+            else
+                ME=MException('labData:Constructor','Tenth argument (HreflexPin) should be a LabTimeSeries object.');
+                throw(ME);
+            end
             %---------------
             %Check that all data is from the same time interval: To Do!
             %---------------
@@ -259,7 +269,7 @@ classdef labData
             %COMDATA=this.CarlysCOMData; %CJS: you should do this!
             
             % 7) Generate processedTrial object
-            processedData=processedTrialData(this.metaData,this.markerData,filteredEMGData,this.GRFData,this.beltSpeedSetData,this.beltSpeedReadData,this.accData,this.EEGData,this.footSwitchData,events,procEMGData,angleData,COPData,COMData,jointMomentsData);
+            processedData=processedTrialData(this.metaData,this.markerData,filteredEMGData,this.GRFData,this.beltSpeedSetData,this.beltSpeedReadData,this.accData,this.EEGData,this.footSwitchData,events,procEMGData,angleData,COPData,COMData,jointMomentsData,this.HreflexPin);
             
             % 8) Calculate adaptation parameters - to be
             % recalculated later!!

--- a/classes/dataStructs/@processedLabData/processedLabData.m
+++ b/classes/dataStructs/@processedLabData/processedLabData.m
@@ -52,8 +52,8 @@ classdef processedLabData < labData
     methods
 
         %Constructor:
-        function this=processedLabData(metaData,markerData,EMGData,GRFData,beltSpeedSetData,beltSpeedReadData,accData,EEGData,footSwitches,events,procEMG,angleData,COPData,COMData,jointMomentsData) %All arguments are mandatory
-            if nargin<15 %metaData does not get replaced!
+        function this=processedLabData(metaData,markerData,EMGData,GRFData,beltSpeedSetData,beltSpeedReadData,accData,EEGData,footSwitches,events,procEMG,angleData,COPData,COMData,jointMomentsData,HreflexPin) %All arguments are mandatory
+            if nargin<16 %metaData does not get replaced!
                markerData=[];
                EMGData=[];
                GRFData=[];
@@ -68,8 +68,9 @@ classdef processedLabData < labData
                COPData=[];
                COMData=[];
                jointMomentsData=[];
+               HreflexPin=[];
             end
-            this@labData(metaData,markerData,EMGData,GRFData,beltSpeedSetData,beltSpeedReadData,accData,EEGData,footSwitches);
+            this@labData(metaData,markerData,EMGData,GRFData,beltSpeedSetData,beltSpeedReadData,accData,EEGData,footSwitches,HreflexPin);
             this.gaitEvents=events;
             this.procEMGData=procEMG;
             this.angleData=angleData;

--- a/classes/dataStructs/@rawTrialData/rawTrialData.m
+++ b/classes/dataStructs/@rawTrialData/rawTrialData.m
@@ -10,12 +10,12 @@ classdef rawTrialData < rawLabData
     
     methods
         %Constructor 
-        function this=rawTrialData(metaData,markerData,EMGData,GRFData,beltSpeedSetData,beltSpeedReadData,accData,EEGData,footSwitches)
+        function this=rawTrialData(metaData,markerData,EMGData,GRFData,beltSpeedSetData,beltSpeedReadData,accData,EEGData,footSwitches,HreflexPin)
             if ~isa(metaData,'trialMetaData') && ~isa(metaData,'derivedMetaData') && ~isempty(metaData)
                 ME=MException('rawTrialData:Constructor','First argument is not a trialMetaData object.');
                 throw(ME);
             end
-            this@rawLabData(metaData,markerData,EMGData,GRFData,beltSpeedSetData,beltSpeedReadData,accData,EEGData,footSwitches);
+            this@rawLabData(metaData,markerData,EMGData,GRFData,beltSpeedSetData,beltSpeedReadData,accData,EEGData,footSwitches,HreflexPin);
         end
     end
     

--- a/classes/dataStructs/processedTrialData.m
+++ b/classes/dataStructs/processedTrialData.m
@@ -14,9 +14,9 @@ classdef processedTrialData < processedLabData
     methods
         
         %Constructor:
-        function this=processedTrialData(metaData,markerData,EMGData,GRFData,beltSpeedSetData,beltSpeedReadData,accData,EEGData,footSwitches,events,procEMG,angleData,COPData,COMData,jointMomentsData); %All arguments are mandatory
+        function this=processedTrialData(metaData,markerData,EMGData,GRFData,beltSpeedSetData,beltSpeedReadData,accData,EEGData,footSwitches,events,procEMG,angleData,COPData,COMData,jointMomentsData,HreflexPin); %All arguments are mandatory
             
-            if nargin<15 %metaData does not get replaced.
+            if nargin<16 %metaData does not get replaced.
                markerData=[];
                EMGData=[];
                GRFData=[];
@@ -31,13 +31,13 @@ classdef processedTrialData < processedLabData
                COPData=[];
                COMData=[];
                jointMomentsData=[];
-               
+               HreflexPin = [];
             end
             if ~isa(metaData,'trialMetaData') && ~isa(metaData,'derivedMetaData') && ~isempty(metaData)
                 ME=MException('processedTrialData:Constructor','First argument is not a trialMetaData object.');
                 throw(ME);
             end
-            this@processedLabData(metaData,markerData,EMGData,GRFData,beltSpeedSetData,beltSpeedReadData,accData,EEGData,footSwitches,events,procEMG,angleData,COPData,COMData,jointMomentsData)
+            this@processedLabData(metaData,markerData,EMGData,GRFData,beltSpeedSetData,beltSpeedReadData,accData,EEGData,footSwitches,events,procEMG,angleData,COPData,COMData,jointMomentsData,HreflexPin)
         end
         
 %         function calcParams(this)

--- a/classes/dataStructs/rawLabData.m
+++ b/classes/dataStructs/rawLabData.m
@@ -12,8 +12,8 @@ classdef rawLabData < labData
     methods
         
         %Constructor:
-        function this=rawLabData(metaData,markerData,EMGData,GRFData,beltSpeedSetData,beltSpeedReadData,accData,EEGData,footSwitches)
-           this@labData(metaData,markerData,EMGData,GRFData,beltSpeedSetData,beltSpeedReadData,accData,EEGData,footSwitches);
+        function this=rawLabData(metaData,markerData,EMGData,GRFData,beltSpeedSetData,beltSpeedReadData,accData,EEGData,footSwitches,HreflexPin)
+           this@labData(metaData,markerData,EMGData,GRFData,beltSpeedSetData,beltSpeedReadData,accData,EEGData,footSwitches,HreflexPin);
         end
     end
     

--- a/gui/importc3d/loadTrials.m
+++ b/gui/importc3d/loadTrials.m
@@ -567,6 +567,34 @@ for t=cell2mat(info.trialnums) %loop through each trial
         accData=[];
     end
 
+    
+    %% Add H-Reflex Stimulator Pin if exists (new expeirmental feature introduced in April 2024)
+    relData=[];
+    stimLabels ={};
+    units={};
+    fieldList=fields(analogs);
+    stimLabelIdx=cellfun(@(x) ~isempty(x),regexp(fieldList,'^Stimulator_Trigger_Sync_'));
+    stimLabelIdx = find(stimLabelIdx);
+    if ~isempty(stimLabelIdx)
+        for j=1:length(stimLabelIdx) %this will only run if the index exists
+            stimLabels{end+1} = fieldList{stimLabelIdx(j)}; %add the label
+            units{end+1}=eval(['analogsInfo.units.',fieldList{stimLabelIdx(j)}]);
+            relData=[relData,analogs.(fieldList{stimLabelIdx(j)})];
+        end
+        HreflexStimPinData = labTimeSeries(relData,0,1/analogsInfo.frequency,stimLabels);
+        %arg: data, t0 (offset in starting of the data, should be 0 like the force plates, as it's analog wired stream into Vicon?),
+        %Ts (1/sampling frequency), labels
+
+        %sanity check, the # of frames should match GRF data
+        if (GRFData.Length ~= HreflexStimPinData.Length)
+            warning(['Hreflex stimulator pin have different length than GRF data. This should never happen. Data is compromised.'])
+        end
+    else
+        %This is needed to work with expeirments that doesn't have this pin.
+        HreflexStimPinData = [];
+    end
+    
+    
     %% MarkerData
     clear analogs* %Save memory space, no longer need analog data, it was already loaded
     if info.kinematics %check to see if there is kinematic data
@@ -638,6 +666,6 @@ for t=cell2mat(info.trialnums) %loop through each trial
     %% Construct trialData
 
     %rawTrialData(metaData,markerData,EMGData,GRFData,beltSpeedSetData,beltSpeedReadData,accData,EEGData,footSwitches)
-    trials{t}=rawTrialData(trialMD{t},markerData,EMGData,GRFData,[],[],accData,[],[]);%organize trial data into organized object of class rawTrialData
+    trials{t}=rawTrialData(trialMD{t},markerData,EMGData,GRFData,[],[],accData,[],[],HreflexStimPinData);%organize trial data into organized object of class rawTrialData
 
 end

--- a/gui/importc3d/loadTrials.m
+++ b/gui/importc3d/loadTrials.m
@@ -566,8 +566,7 @@ for t=cell2mat(info.trialnums) %loop through each trial
         EMGData=[];
         accData=[];
     end
-
-    
+   
     %% Add H-Reflex Stimulator Pin if exists (new expeirmental feature introduced in April 2024)
     relData=[];
     stimLabels ={};
@@ -587,7 +586,7 @@ for t=cell2mat(info.trialnums) %loop through each trial
 
         %sanity check, the # of frames should match GRF data
         if (GRFData.Length ~= HreflexStimPinData.Length)
-            warning(['Hreflex stimulator pin have different length than GRF data. This should never happen. Data is compromised.'])
+            error('Hreflex stimulator pin have different length than GRF data. This should never happen. Data is compromised.')
         end
     else
         %This is needed to work with expeirments that doesn't have this pin.


### PR DESCRIPTION
When an Hreflex stimulation is being delivered, 2 analogue pin will record a copy of the signal representing stimulation time (one for each leg). Support processing the pin information into labtools for H-reflex synchronization later on. This commit will bring the pin information into raw and experimentData object. 