### PR TITLE
bug fix for datlog loading + sep conditions with new name

### DIFF
--- a/gui/importc3d/getTrialMetaData.m
+++ b/gui/importc3d/getTrialMetaData.m
@@ -42,10 +42,10 @@ for cond = sort(info.cond)
         if datlogExist %datalog folder found, load it.
             filenameDatlog = [datalogFolder filesep basename sprintf('%02d',t)];
             try
-            % Upload the datalog for the specifica condition   
-            info.datlog{cond} = load([filenameDatlog '.mat']);
+                % Upload the datalog for the specifica condition   
+                info.datlog{cond} = load([filenameDatlog '.mat']);
             catch ME
-                warning('Datalog folder exists (%s) but could not find datalog file for trial: %s. Maybe forget to rename them? Will ignore this trial.',datalogFolder,[basename sprintf('%02d',t)])
+                error('Datalog folder exists (%s) but could not find datalog file for trial: %s. Maybe forget to rename them? Will ignore this trial.',datalogFolder,[basename sprintf('%02d',t)])
             end
         end
                 


### PR DESCRIPTION
- datlog make it throw error for where file is missing
- update trialdata.metadata to have the same name as the expData.metaData